### PR TITLE
Added a toggle to show/hide "Ping: <number>"

### DIFF
--- a/src/frontend-common/common_host.cpp
+++ b/src/frontend-common/common_host.cpp
@@ -688,6 +688,11 @@ DEFINE_HOTKEY("ToggleDesyncNotifications", TRANSLATABLE("Hotkeys", "Netplay"), T
                 if (!pressed)
                   Netplay::ToggleDesyncNotifications();
               })
+DEFINE_HOTKEY("TogglePingNotification", TRANSLATABLE("Hotkeys", "Netplay"),
+              TRANSLATABLE("Hotkeys", "Toggle Ping Notifications"), [](s32 pressed) {
+                if (!pressed)
+                  ImGuiManager::TogglePingNotification();
+              })
 #endif
 
 DEFINE_HOTKEY("FastForward", TRANSLATABLE("Hotkeys", "General"), TRANSLATABLE("Hotkeys", "Fast Forward"),

--- a/src/frontend-common/common_host.h
+++ b/src/frontend-common/common_host.h
@@ -53,4 +53,5 @@ std::unique_ptr<AudioStream> CreateXAudio2Stream(u32 sample_rate, u32 channels, 
 
 namespace ImGuiManager {
 void RenderDebugWindows();
+void TogglePingNotification();
 }

--- a/src/frontend-common/imgui_netplay.cpp
+++ b/src/frontend-common/imgui_netplay.cpp
@@ -135,13 +135,22 @@ void ImGuiManager::DrawNetplayMessages()
   }
 }
 
+void ImGuiManager::TogglePingNotification()
+{
+  bool was_enabled_ping = show_ping_notification;
+  show_ping_notification = show_ping_notification ? false : true;
+}
+
 void ImGuiManager::DrawNetplayStats()
 {
   // Not much yet.. eventually we'll render chat and such here too.
   // We'll probably want to draw a graph too..
 
   LargeString text;
-  text.AppendFmtString("Ping: {}\n", Netplay::GetPing());
+  if (show_ping_notification)
+  {
+    text.AppendFmtString("Ping: {}\n", Netplay::GetPing());
+  }
 
   // temporary show the hostcode here for now
   auto hostcode = Netplay::GetHostCode();

--- a/src/frontend-common/imgui_netplay.cpp
+++ b/src/frontend-common/imgui_netplay.cpp
@@ -65,6 +65,7 @@ static constexpr float NETPLAY_MESSAGE_FADE_TIME = 2.0f;
 static bool s_netplay_chat_dialog_open = false;
 static bool s_netplay_chat_dialog_opening = false;
 static std::string s_netplay_chat_message;
+static bool show_ping_notification;
 
 void Host::OnNetplayMessage(std::string message)
 {
@@ -137,7 +138,6 @@ void ImGuiManager::DrawNetplayMessages()
 
 void ImGuiManager::TogglePingNotification()
 {
-  bool was_enabled_ping = show_ping_notification;
   show_ping_notification = show_ping_notification ? false : true;
 }
 


### PR DESCRIPTION
Hi,

I absolutely love the netplay feature in DuckStation, especially when using it while traveling with a friend and both bringing an ROG Ally X. Since our ping is almost always good (we're on LAN), we wanted to disable or hide the ping notification that's always displayed. I checked Discord but couldn't find any information on whether this was possible, and I noticed that you're quite busy.

So, instead of requesting the feature, I went ahead and implemented it myself. It was just a very minor code change, and I made sure to follow your coding style by implementing it in the same way as the ToggleDesyncNotification option.

This addition is based on the nat-traversal branch, as I noticed that this was the most up-to-date branch according to the release notes.

Thought I made a pull request in case you wanted to add this.

To sum it up:

- Added a define hotkey beneath the ToggleDesyncNotification option
- Created small function to actually toggle the value
- If statement around the "Ping:<#>" message

kind regards

